### PR TITLE
Do not use the haste Model

### DIFF
--- a/src/Model/Model.php
+++ b/src/Model/Model.php
@@ -18,7 +18,7 @@ use Exception;
 use Contao\Database;
 use WEM\UtilsBundle\Classes\QueryBuilder;
 
-abstract class Model extends \Haste\Model\Model
+abstract class Model extends \Contao\Model
 {
     /**
      * Default order column


### PR DESCRIPTION
A simple modification, but might have consequences. Haste decided to rename the Model extension in 5.0 so if we want to be compatible with 4.x and 5.x, we have to remove that extends too.
They changed it because their abstract class only deals with DCA with relations: https://github.com/codefog/contao-haste/commit/f0e30b54bf41314e1bcf08ae3304bf2d34b5d0a7

If this causes any issues, we can just extend from the replaced classes: https://github.com/codefog/contao-haste/blob/main/src/Model/DcaRelationsModel.php